### PR TITLE
Use img instead of lcd to draw string with UnitV

### DIFF
--- a/machine_vision/yolov2_20class.py
+++ b/machine_vision/yolov2_20class.py
@@ -22,9 +22,8 @@ while(True):
         for i in code:
             a=img.draw_rectangle(i.rect())
             a = lcd.display(img)
-            for i in code:
-                lcd.draw_string(i.x(), i.y(), classes[i.classid()], lcd.RED, lcd.WHITE)
-                lcd.draw_string(i.x(), i.y()+12, '%.3f'%i.value(), lcd.RED, lcd.WHITE)
+            lcd.draw_string(i.x(), i.y(), classes[i.classid()], lcd.RED, lcd.WHITE)
+            lcd.draw_string(i.x(), i.y()+12, '%.3f'%i.value(), lcd.RED, lcd.WHITE)
     else:   
         a = lcd.display(img)
 a = kpu.deinit(task)

--- a/machine_vision/yolov2_20class.py
+++ b/machine_vision/yolov2_20class.py
@@ -21,9 +21,9 @@ while(True):
     if code:
         for i in code:
             a=img.draw_rectangle(i.rect())
+            img.draw_string(i.x(), i.y(), classes[i.classid()], color=(255, 0, 0), scale=2)
+            img.draw_string(i.x(), i.y()+24, '%.3f'%i.value(), color=(255, 0, 0), scale=2)
             a = lcd.display(img)
-            lcd.draw_string(i.x(), i.y(), classes[i.classid()], lcd.RED, lcd.WHITE)
-            lcd.draw_string(i.x(), i.y()+12, '%.3f'%i.value(), lcd.RED, lcd.WHITE)
     else:   
         a = lcd.display(img)
 a = kpu.deinit(task)


### PR DESCRIPTION
I use `img` instead of` lcd` to draw string with UnitV.

lcd.draw_string() is a function to write text directly on the LCD.
Since I am using UnitV+MaixPy IDE, I cannot use lcd.draw_string() to draw text.

With this pull request, image output is like below:
![Screenshot 2021-08-09 12:01:09](https://user-images.githubusercontent.com/19769486/128656386-89c028b8-44d6-4e2b-83c6-5750dc2797d8.png)

cc @YamaguchiAtsushi
